### PR TITLE
Changed optional argument "--tag" to "--tagtype"

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ optional arguments:
                         Detail level of the grammar. An integer > 0
                         proportional to the desired specificity.
   -v                    verbose level (e.g., -vvv)
-  --tags {pos_semantic,pos,backoff,word}
+  --tagtype {pos_semantic,pos,backoff,word}
   -w NUM_WORKERS, --num_workers NUM_WORKERS
                         number of cores available for parallel work
 


### PR DESCRIPTION
As per line 586 of train.py, the tag type is given to the program with the argument --tagtype rather than --tag.